### PR TITLE
Handle Chef search mapping correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .bundle
+bin

--- a/libraries/feature.rb
+++ b/libraries/feature.rb
@@ -106,7 +106,7 @@ module PagerDuty
 
     def stable_scoped_search(scope)
       Chef::Log.debug("Feature check: performing scoped search '#{scope}'")
-      search(:node, scope, filter_result: { 'name' => ['name'] }).map(&:name).sort
+      search(:node, scope, filter_result: { 'name' => ['name'] }).map{ |h| h['name'] }.sort
     end
 
     def feature_translate(boolean)

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -9,7 +9,7 @@ describe 'pd-feature-test::role' do
   end
 
   before do
-    stub_search('node', 'chef_environment:_default AND roles:app').and_return((1..3).map { |i| Chef::Node.build("node#{i}") })
+    stub_search('node', 'chef_environment:_default AND roles:app').and_return((1..3).map { |i| { 'name' => "node#{i}" } })
   end
 
   it 'enables the feature for the first app node' do

--- a/spec/rules_spec.rb
+++ b/spec/rules_spec.rb
@@ -9,7 +9,7 @@ describe 'pd-feature-test::rules' do
   end
 
   before do
-    stub_search('node', 'chef_environment:_default').and_return((1..3).map { |i| Chef::Node.build("node#{i}") })
+    stub_search('node', 'chef_environment:_default').and_return((1..3).map { |i| { 'name' => "node#{i}" } })
   end
 
   it 'selects the first node to participate in both groups' do


### PR DESCRIPTION
Partial searches return `Hash`es, not `Chef::Node`s.