### PR TITLE
Avoid crashing when the node doesn't show up in the search

### DIFF
--- a/libraries/feature.rb
+++ b/libraries/feature.rb
@@ -66,7 +66,11 @@ module PagerDuty
       count = arg.to_i
 
       result = stable_scoped_search(context[:search])
-      Chef::Log.debug("Feature check: this node's position for feature '#{context[:name]}' is #{result.index(node.name) + 1} out of #{result.length}")
+      if result.index(node.name)
+        Chef::Log.debug("Feature check: this node's position for feature '#{context[:name]}' is #{result.index(node.name) + 1} out of #{result.length}")
+      else
+        Chef::Log.debug("Feature check: this node does not show up in the search for feature '#{context[:name]}'")
+      end
       result.first(count).include? node.name
     end
 
@@ -75,7 +79,11 @@ module PagerDuty
 
       result = stable_scoped_search(context[:search])
       count = (result.length * percent / 100).floor
-      Chef::Log.debug("Feature check: this node's percentage position for feature '#{context[:name]}' is #{format('%.1f', (result.index(node.name) + 1.0) / result.length * 100.0)}")
+      if result.index(node.name)
+        Chef::Log.debug("Feature check: this node's percentage position for feature '#{context[:name]}' is #{format('%.1f', (result.index(node.name) + 1.0) / result.length * 100.0)}")
+      else
+        Chef::Log.debug("Feature check: this node does not show up in the search for feature '#{context[:name]}'")
+      end
       result.first(count).include? node.name
     end
 

--- a/spec/rules_spec.rb
+++ b/spec/rules_spec.rb
@@ -44,4 +44,18 @@ describe 'pd-feature-test::rules' do
       expect(subject).to_not create_file('percent')
     end
   end
+
+  context 'for a node being provisioned' do
+    subject do
+      ChefSpec::SoloRunner.new do |node|
+        node.name 'node0'
+        node.chef_environment '_default'
+      end.converge(described_recipe)
+    end
+
+    it 'selects the node to participate in neither group' do
+      expect(subject).to_not create_file('count')
+      expect(subject).to_not create_file('percent')
+    end
+  end
 end


### PR DESCRIPTION
This can happen during provisioning, or if the search is intentionally
scoped to exclude the node in question.